### PR TITLE
Add support for UTF8 config files

### DIFF
--- a/lib/Config/Any/TOML.pm
+++ b/lib/Config/Any/TOML.pm
@@ -35,12 +35,15 @@ sub load {
     my $file  = shift;
 
     open( my $fh, $file ) or die $!;
+    binmode $fh;
+
     my $content = do { local $/; <$fh> };
     close $fh;
 
+    require Encode;
     require TOML;
 
-    my ( $data, $err ) = TOML::from_toml($content);
+    my ( $data, $err ) = TOML::from_toml( Encode::decode('UTF-8', $content ) );
         unless ($data) {
         die "Error parsing toml: $err";
     }

--- a/t/toml.t
+++ b/t/toml.t
@@ -3,6 +3,7 @@ use warnings;
 
 use Test::More;
 use Config::Any::TOML;
+use utf8;
 
 subtest 'TOML' => sub {
     if ( !Config::Any::TOML->is_supported ) {
@@ -12,6 +13,7 @@ subtest 'TOML' => sub {
     my $config = Config::Any::TOML->load('t/conf/conf.toml');
     ok($config);
     is( $config->{title}, 'TOML Example' );
+    is( $config->{servers}{beta}{country}, '中国' );
 
     # test invalid config
 


### PR DESCRIPTION
Although the test data included some UTF8 strings, this was not being tested, so the test was not catching the fact that it was being mangled on loading.

This fix might not be ideal, but it is equivalent to [the fix in the upstream Config::Any::JSON module](http://git.shadowcat.co.uk/gitweb/gitweb.cgi?p=p5sagit/Config-Any.git;a=commitdiff;h=3a27e96d3f96ae99fa6bc1a78ec420b0a6392f0d).
